### PR TITLE
Bump version to 3.0.0-SNAPSHOT for XP 8

### DIFF
--- a/.github/workflows/enonic-gradle.yml
+++ b/.github/workflows/enonic-gradle.yml
@@ -13,6 +13,9 @@ jobs:
         with:
           repoUser: ci
           repoPassword: ${{ secrets.ARTIFACTORY_PASSWORD }}
+          releaseBranch: |
+            master
+            2.x
 
   release:
     runs-on: ubuntu-latest

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,4 @@ appDisplayName=LDAP ID Provider
 vendorName=Enonic AS
 vendorUrl=http://enonic.com
 xpVersion=8.0.0-B4
-version=2.1.2-SNAPSHOT
+version=3.0.0-SNAPSHOT


### PR DESCRIPTION
## Summary

- Bump master `version` from `2.1.2-SNAPSHOT` to `3.0.0-SNAPSHOT` to track the XP 8 line.
- Add `releaseBranch:` config to `.github/workflows/enonic-gradle.yml` so both `master` and `2.x` are treated as release branches by `enonic/release-tools/build-and-publish`.
- The XP 7 maintenance line continues on the new `2.x` branch (created at the post-`v2.1.1-RC1` SNAPSHOT commit `9decd4a`, where `gradle.properties` is `version=2.1.1-SNAPSHOT`).

A companion PR against `2.x` adds the same `releaseBranch:` config there so pushes to `2.x` are recognized as release-branch builds.

## Test plan

- [ ] CI build green on this PR.
- [ ] After merge, a build on `master` from the next push.