### PR TITLE
Bump lib-mustache to 3.0.0-SNAPSHOT #68

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,5 +20,5 @@ dependencies {
 repositories {
     mavenLocal()
     mavenCentral()
-    xp.enonicRepo()
+    xp.enonicRepo('dev')
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-mustache            = "2.1.1"
+mustache            = "3.0.0-SNAPSHOT"
 
 [libraries]
 lib-mustache          = { module = "com.enonic.lib:lib-mustache",          version.ref = "mustache" }


### PR DESCRIPTION
## Summary

Bumps `lib-mustache` from `2.1.1` → `3.0.0-SNAPSHOT` (XP 8 build of the
library, published on `repo.enonic.com/dev`), and switches
`xp.enonicRepo()` to `xp.enonicRepo('dev')` so the SNAPSHOT resolves.

Surfaced while running the XP 8 E2E verification (#68): the SNAPSHOT is
recommended for XP 8 apps consuming lib-mustache.

## Verified

- `./gradlew build --refresh-dependencies` passes against `xpVersion=8.0.0-B4`.
- Booted XP 8.0.0-B4 with the app installed, bundle reached ACTIVE.
- Bootstrapped an idprovider node + vhost mapping, hit `/_/idprovider/ldap/login`:
  responds HTTP 200 with the rendered login HTML (mustache template
  rendered, title `LDAP Login`, asset URLs wired).
- No errors / `NoClassDef` / `NoSuchMethod` in `server.log`.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)